### PR TITLE
[FIX] Adding motorgroup class cross thread accessability feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ vexide = "0.7.0"
 libm = { version = "0.2", default-features = false }
 uom = { version = "0.36.0", default-features = false, features = ["f64", "si"] }
 embassy-sync = "0.7.0"
+spin = { version = "0.9", default-features = false, features = ["once", "mutex", "spin_mutex"] }

--- a/src/GravLib/actuator/motor_group.rs
+++ b/src/GravLib/actuator/motor_group.rs
@@ -1,51 +1,36 @@
+// motorgroup.rs
 extern crate alloc;
 
+use alloc::boxed::Box;
 use alloc::vec::Vec;
+use vexide::devices::adi::motor;
+use core::time::Duration;
+use spin::Mutex;
 use vexide::prelude::{BrakeMode, Gearset, Motor};
+use vexide::task;
+use libm::roundf;
 
-use uom::si::{angular_velocity::*, f64::AngularVelocity, velocity};
-use libm::{roundf, round};  
-
-pub struct motorGroup {
-    motors: Vec<Motor>
+pub struct MotorGroup {
+    inner: &'static Mutex<Inner>,
 }
 
+struct Inner {
+    motors: Vec<Motor>,
+}
 
-impl motorGroup {
-    pub fn new(motors: Vec<Motor>) -> Self {
+impl Inner{
+    fn new(motors: Vec<Motor>) -> Self {
         Self { motors }
     }
 
-    pub fn set_voltage(&mut self, voltage: f64) {
-        for motor in self.motors.iter_mut() {
-            let _ = motor.set_voltage(voltage);
+    fn move_voltage(&mut self, voltage: f64) {
+        for motor in &mut self.motors {
+            let _ = motor.set_voltage(voltage); 
         }
     }
-    
-    pub fn voltage(&self) -> f64 {
-        let mut total = 0.0;
 
-        for motor in &self.motors {
-            if let Ok(voltage) = motor.voltage() {
-                total += voltage;
-            }
-        }
-        total / self.motors.len() as f64
-    }
-
-
-    pub fn position(&self) -> f64 {
-        let mut total = 0.0;
-        for motor in &self.motors {
-            if let Ok(angle) = motor.position() {
-                total += angle.as_radians();
-            }
-        }
-        total
-    }
-
-        // @dev_note: set_velocity method is built in PID by VEXIDE devs.
-    pub fn set_velocity(&mut self, velocity_percentage: f64) {
+    // @dev_note: set_velocity method is built in PID by VEXIDE devs.
+    fn move_velocity(&mut self, velocity_percentage: f64) {
         // Calculate velocity as percentage of max velocity
 
         for motor in self.motors.iter_mut() {
@@ -67,9 +52,154 @@ impl motorGroup {
         }
     }
 
-    pub fn brake(&mut self, mode: BrakeMode) {
+    fn voltage(&self) -> f64 {
+        let mut total = 0.0;
+
+        for motor in &self.motors {
+            if let Ok(voltage) = motor.voltage() {
+                total += voltage;
+            }
+        }
+        total / self.motors.len() as f64
+    }
+    
+    fn position(&self) -> f64 {
+        let mut total = 0.0;
+        for motor in &self.motors {
+            if let Ok(angle) = motor.position() {
+                total += angle.as_radians();
+            }
+        }
+        total
+    }
+    
+
+    fn brake(&mut self, mode: BrakeMode) {
         for motor in self.motors.iter_mut() {
             let _ = motor.brake(mode);
         }
     }
 }
+
+
+impl MotorGroup {
+    pub fn new(motors: Vec<Motor>) -> Self {
+        let boxed = Box::new(Mutex::new(Inner::new(motors)));
+        let static_mutex = Box::leak(boxed); // leak the Box to get a static reference
+
+        let handle: MotorGroup = MotorGroup {inner: static_mutex}; 
+        // task::spawn(Self::tracking_task(handle.inner)).detach(); // TODO - optional, useable in chasiss, spawn background tracking task
+
+        handle
+    }
+
+    pub fn set_voltage(&self, voltage: f64) {
+        let mut guard = self.inner.lock();
+        guard.set_voltage(voltage);
+    }
+
+    pub fn voltage(&self) -> f64 {
+        let guard = self.inner.lock();
+        guard.voltage()
+    }
+
+    pub fn position(&self) -> f64 {
+        let guard = self.inner.lock();
+        guard.position()
+    }
+
+    pub fn set_velocity(&self, velocity_percentage: f64) {
+        let mut guard = self.inner.lock();
+        guard.set_velocity(velocity_percentage);
+    }
+
+    pub fn brake(&self, mode: BrakeMode) {
+        let mut guard = self.inner.lock();
+        guard.brake(mode);
+    }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+// _________________________________________ //
+
+
+
+
+
+// pub struct motorGroup {
+//     motors: Vec<Motor>
+// }
+
+
+// impl motorGroup {
+//     pub fn new(motors: Vec<Motor>) -> Self {
+//         Self { motors }
+//     }
+
+//     pub fn set_voltage(&mut self, voltage: f64) {
+//         for motor in self.motors.iter_mut() {
+//             let _ = motor.set_voltage(voltage);
+//         }
+//     }
+    
+//     pub fn voltage(&self) -> f64 {
+//         let mut total = 0.0;
+
+//         for motor in &self.motors {
+//             if let Ok(voltage) = motor.voltage() {
+//                 total += voltage;
+//             }
+//         }
+//         total / self.motors.len() as f64
+//     }
+
+
+//     pub fn position(&self) -> f64 {
+//         let mut total = 0.0;
+//         for motor in &self.motors {
+//             if let Ok(angle) = motor.position() {
+//                 total += angle.as_radians();
+//             }
+//         }
+//         total
+//     }
+
+//         // @dev_note: set_velocity method is built in PID by VEXIDE devs.
+//     pub fn set_velocity(&mut self, velocity_percentage: f64) {
+//         // Calculate velocity as percentage of max velocity
+
+//         for motor in self.motors.iter_mut() {
+//             let gearset = motor.gearset().unwrap();
+
+//             let max_rpm = match gearset {
+//                 Gearset::Red   => 100,
+//                 Gearset::Green => 200,
+//                 Gearset::Blue  => 600,
+//             };
+
+//             // Convert percentages to rpm
+//             let velocity_raw = 
+//                 (velocity_percentage as f32 / 100.0)
+//                 * (max_rpm as f32);
+
+//             let velocity = roundf(velocity_raw) as i32;
+//             let _ = motor.set_velocity(velocity);
+//         }
+//     }
+
+//     pub fn brake(&mut self, mode: BrakeMode) {
+//         for motor in self.motors.iter_mut() {
+//             let _ = motor.brake(mode);
+//         }
+//     }
+// }

--- a/src/GravLib/actuator/motor_group.rs
+++ b/src/GravLib/actuator/motor_group.rs
@@ -93,9 +93,14 @@ impl MotorGroup {
         handle
     }
 
-    pub fn set_voltage(&self, voltage: f64) {
+    pub fn move_voltage(&self, voltage: f64) {
         let mut guard = self.inner.lock();
-        guard.set_voltage(voltage);
+        guard.move_voltage(voltage);
+    }
+
+    pub fn move_velocity(&self, velocity_percentage: f64) {
+        let mut guard = self.inner.lock();
+        guard.move_velocity(velocity_percentage);
     }
 
     pub fn voltage(&self) -> f64 {
@@ -106,11 +111,6 @@ impl MotorGroup {
     pub fn position(&self) -> f64 {
         let guard = self.inner.lock();
         guard.position()
-    }
-
-    pub fn set_velocity(&self, velocity_percentage: f64) {
-        let mut guard = self.inner.lock();
-        guard.set_velocity(velocity_percentage);
     }
 
     pub fn brake(&self, mode: BrakeMode) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,7 +75,7 @@ async fn main(peripherals: Peripherals) {
     // }
     // sleep(Duration::from_secs(1_000)).await;
 
-    m1.set_voltage(6.0);
+    m1.move_voltage(6.0);
     sleep(Duration::from_secs(1)).await;
     m1.brake(BrakeMode::Coast);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,62 +4,90 @@ extern crate alloc;
 mod GravLib;
 
 use core::time::Duration;
-
+use spin::Mutex;
 use alloc::vec::Vec;
+use alloc::boxed::Box;
 
 use vexide::{devices::adi::motor, prelude::*};
-use crate::GravLib::*;
+use crate::GravLib::actuator::motor_group::motorGroup;
+
+//------------------------------------------------------
+// 1) Change your worker to take a &'static Mutex<motorGroup>
+//------------------------------------------------------
+async fn location_track(g: &'static Mutex<motorGroup>) {
+    loop {
+        {
+            let mut guard = g.lock();  // lock the mutex, protecting it from other task access
+            println!(
+                "Voltage: {} | Position: {}",
+                guard.voltage(),
+                guard.position()
+            );
+            // guard dropped here, stop protection
+        }
+        sleep(Duration::from_millis(100)).await;
+    }
+}
 
 struct Robot {}
-
 impl Compete for Robot {
     async fn autonomous(&mut self) {
         println!("Autonomous!");
     }
-
     async fn driver(&mut self) {
         println!("Driver!");
     }
 }
 
-async fn location_track(group_ptr: *mut actuator::motor_group::motorGroup) {
-    loop {
-        unsafe {
-            let group: &actuator::motor_group::motorGroup = &*group_ptr;
-            println!(
-                "Voltage: {} | Position {}",
-                group.voltage(),
-                group.position()
-            );
-        }
-        sleep(Duration::from_millis(100)).await;
-    }
-}
 #[vexide::main]
 async fn main(peripherals: Peripherals) {
     let robot = Robot {};
 
-    let motors = Vec::from([
-        Motor::new(peripherals.port_1, Gearset::Green, Direction::Forward),
-        Motor::new(peripherals.port_2, Gearset::Green, Direction::Reverse),
-    ]);
 
-    let mut funny = actuator::motor_group::motorGroup::new(motors);
+    //------------------------------------------------------
+    // SECTION 1: ROBOT CONFIGURATION
+    //------------------------------------------------------
 
-    let funny_ptr: *mut actuator::motor_group::motorGroup = &mut funny as *mut _;
-    vexide::task::spawn(location_track(funny_ptr)).detach();
 
-    funny.set_voltage(-6.0);
+    //------------------------------------------------------
+    // 2) Allocate your Mutex<motorGroup> on the heap and leak it,
+    //    so you get a &'static reference you can both spawn
+    //    and continue to use in `main`.
+    //------------------------------------------------------
+    let boxed_group = Box::new(Mutex::new(
+        motorGroup::new(
+            Vec::from([
+                Motor::new(peripherals.port_1, Gearset::Green, Direction::Forward),
+                Motor::new(peripherals.port_2, Gearset::Green, Direction::Reverse),
+            ])
+        )
+    )); 
+    let static_group: &'static Mutex<motorGroup> = Box::leak(boxed_group); // leak the Box to get a static reference
+           // Why static reference? to extend **LIFETIME** to ENTIRE PROGRAM
 
+    // 3) Spawn the tracking task
+    vexide::task::spawn(location_track(static_group)).detach();
+
+    //------------------------------------------------------
+
+    {
+        let mut guard = static_group.lock(); // lock the mutex to access the motor group
+        guard.set_voltage(-6.0);
+    }
     sleep(Duration::from_secs(1)).await;
 
-    funny.set_voltage(6.0);
-
+    {
+        let mut guard = static_group.lock();
+        guard.set_voltage(6.0);
+    }
     sleep(Duration::from_secs(1)).await;
 
-    funny.brake(BrakeMode::Coast);
+    {
+        let mut guard = static_group.lock();
+        guard.brake(BrakeMode::Coast);
+    }
+    sleep(Duration::from_secs(1_000)).await;
 
-    sleep(Duration::from_secs(1000)).await;
-
-    // robot.compete().await;
+    // 5) Finally run your Robot
+    robot.compete().await;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,25 +9,25 @@ use alloc::vec::Vec;
 use alloc::boxed::Box;
 
 use vexide::{devices::adi::motor, prelude::*};
-use crate::GravLib::actuator::motor_group::motorGroup;
+use crate::GravLib::actuator::motor_group::MotorGroup;
 
 //------------------------------------------------------
 // 1) Change your worker to take a &'static Mutex<motorGroup>
 //------------------------------------------------------
-async fn location_track(g: &'static Mutex<motorGroup>) {
-    loop {
-        {
-            let mut guard = g.lock();  // lock the mutex, protecting it from other task access
-            println!(
-                "Voltage: {} | Position: {}",
-                guard.voltage(),
-                guard.position()
-            );
-            // guard dropped here, stop protection
-        }
-        sleep(Duration::from_millis(100)).await;
-    }
-}
+// async fn location_track(g: &'static Mutex<motorGroup>) {
+//     loop {
+//         {
+//             let mut guard = g.lock();  // lock the mutex, protecting it from other task access
+//             println!(
+//                 "Voltage: {} | Position: {}",
+//                 guard.voltage(),
+//                 guard.position()
+//             );
+//             // guard dropped here, stop protection
+//         }
+//         sleep(Duration::from_millis(100)).await;
+//     }
+// }
 
 struct Robot {}
 impl Compete for Robot {
@@ -48,45 +48,36 @@ async fn main(peripherals: Peripherals) {
     // SECTION 1: ROBOT CONFIGURATION
     //------------------------------------------------------
 
-
-    //------------------------------------------------------
-    // 2) Allocate your Mutex<motorGroup> on the heap and leak it,
-    //    so you get a &'static reference you can both spawn
-    //    and continue to use in `main`.
-    //------------------------------------------------------
-    let boxed_group = Box::new(Mutex::new(
-        motorGroup::new(
-            Vec::from([
-                Motor::new(peripherals.port_1, Gearset::Green, Direction::Forward),
-                Motor::new(peripherals.port_2, Gearset::Green, Direction::Reverse),
-            ])
-        )
-    )); 
-    let static_group: &'static Mutex<motorGroup> = Box::leak(boxed_group); // leak the Box to get a static reference
-           // Why static reference? to extend **LIFETIME** to ENTIRE PROGRAM
-
-    // 3) Spawn the tracking task
-    vexide::task::spawn(location_track(static_group)).detach();
+    let mut m1 = MotorGroup::new(
+        Vec::from([
+            Motor::new(peripherals.port_1, Gearset::Green, Direction::Forward),
+            Motor::new(peripherals.port_2, Gearset::Green, Direction::Reverse),
+        ])
+    );
 
     //------------------------------------------------------
 
-    {
-        let mut guard = static_group.lock(); // lock the mutex to access the motor group
-        guard.set_voltage(-6.0);
-    }
+    // {
+    //     let mut guard = static_group.lock(); // lock the mutex to access the motor group
+    //     guard.set_voltage(-6.0);
+    // }
+    // sleep(Duration::from_secs(1)).await;
+
+    // {
+    //     let mut guard = static_group.lock();
+    //     guard.set_voltage(6.0);
+    // }
+    // sleep(Duration::from_secs(1)).await;
+
+    // {
+    //     let mut guard = static_group.lock();
+    //     guard.brake(BrakeMode::Coast);
+    // }
+    // sleep(Duration::from_secs(1_000)).await;
+
+    m1.set_voltage(6.0);
     sleep(Duration::from_secs(1)).await;
-
-    {
-        let mut guard = static_group.lock();
-        guard.set_voltage(6.0);
-    }
-    sleep(Duration::from_secs(1)).await;
-
-    {
-        let mut guard = static_group.lock();
-        guard.brake(BrakeMode::Coast);
-    }
-    sleep(Duration::from_secs(1_000)).await;
+    m1.brake(BrakeMode::Coast);
 
     // 5) Finally run your Robot
     robot.compete().await;


### PR DESCRIPTION
<!--
Thank you for your contribution to GravLib! Please fill out the sections below to help us review your PR faster.
-->

## 📋 Description

<!--
A clear and concise description of what this PR does.
Replace this with your own summary.
-->
**What this is**  
Adds a thread-safe MotorGroup wrapper around the existing motorGroup struct, with a leaked static Mutex for cross-task access.

**Why this is needed**  
We need a safe way to share a single MotorGroup instance between asynchronous tasks without resorting to unsafe pointers.

## 🆕 Type of Change

<!--
Put an `x` in the boxes that apply. You can also add your own.
-->
- [x] 🐛 Bug fix  
- [ ] ✨ New feature  
- [ ] 📚 Documentation update  
- [ ] ⚠️ Breaking change  

## ✅ How Has This Been Tested?

<!--
Describe how you tested your changes. Include details of your test environment, and what kind of tests you ran:
e.g., unit tests, integration tests, manual smoke tests, etc.
-->
- [x] manually tested with V5 Brain and 2 11w motor system
  1. ran routine spinning motor, accessing it. 
  2. ran monitoring thread, which did not affect motor routine. 

---

<!--
Use one of the following keywords to auto-close issues when this PR is merged:
Closes, Fixes, Resolves
Example: “Closes #42”
-->
